### PR TITLE
Convert string ref to callback ref

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,13 +20,12 @@ class DateTimePicker extends Component {
   }
 
   componentDidMount() {
-    const node = findDOMNode(this.refs.input)
     const options = {
         ...this.props.options,
         onChange: this.props.onChange
     }
 
-    this.flatpickr = new Flatpickr(node, options)
+    this.flatpickr = new Flatpickr(this.node, options)
   }
 
   render() {
@@ -34,7 +33,7 @@ class DateTimePicker extends Component {
     // eslint-disable-next-line no-unused-vars
     const { onChange, options, defaultValue, value, ...props } = this.props
     return (
-      <input {...props} defaultValue={defaultValue || value} ref='input' />
+      <input {...props} defaultValue={defaultValue || value} ref={(node) => this.node = node} />
     )
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 
 import React, { Component, PropTypes } from 'react'
-import { findDOMNode } from 'react-dom'
 import Flatpickr from 'flatpickr'
 
 class DateTimePicker extends Component {


### PR DESCRIPTION
Facebook recommends using callback functions for refs, and has deprecated the use of string refs. This PR updates this component to follow that recommendation.

P.S. Reading through the docs, it looks like they removed any reference to string refs altogether. https://facebook.github.io/react/docs/refs-and-the-dom.html