### PR TITLE
Fix infinite loop with controlled components

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ class DateTimePicker extends Component {
 
   componentWillReceiveProps(props) {
     if (props.value) {
-      this.flatpickr.setDate(props.value)
+      this.flatpickr.setDate(props.value, false)
     }
 
     const optionsKeys = Object.getOwnPropertyNames(props.options)


### PR DESCRIPTION
Because of [this line](https://github.com/chmln/flatpickr/blob/master/src/flatpickr.js#L1418) in flatpickr, if you don't explicitly pass `false` to `setDate` it will trigger events, including the `onChange` event. This leads to an infinite loop when using this package as a controlled component.

Alternatively, I believe you can bind to `onValueUpdate` instead of `onChange`, that's what [the vue version of this package does](https://github.com/jrainlau/vue-flatpickr/blob/2.0/src/components/vue-flatpickr.vue#L45) and it doesn't seem to suffer from this issue.