### PR TITLE
Call setDate after creating flatpickr

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,10 @@ class DateTimePicker extends Component {
     }
 
     this.flatpickr = new Flatpickr(this.node, options)
+
+	if (this.props.hasOwnProperty('value')) {
+	  this.flatpickr.setDate(this.props.value, false)
+	}
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Without this change, initial values for date ranges aren't possible because in the first pass `value` is just set directly on the input element, which obviously doesn't work very well with arrays.

This calls setDate immediately after creating the flatpickr so there's no discrepancy between the first pass (used to just set on input element) and subsequent passes (`setDate` is called in `componentWillReceiveProps`).