### PR TITLE
change `defaultValue` and `value` PropType

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,10 +5,10 @@ import Flatpickr from 'flatpickr'
 
 class DateTimePicker extends Component {
   static propTypes = {
-    defaultValue: PropTypes.string,
+    defaultValue: PropTypes.object,
     options: PropTypes.object,
     onChange: PropTypes.func,
-    value: PropTypes.string,
+    value: PropTypes.object,
     children: PropTypes.node
   }
 


### PR DESCRIPTION
change `defaultValue` and `value` PropType to object, because we can give some Date or Array value.

refer：
https://chmln.github.io/flatpickr/instance-methods-properties-elements/#setdate-date-triggerchange