### PR TITLE
Make 'prop-types', 'react' and 'react-dom' dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "flatpickr": "^2.3.5",
-    "prop-types": "^15.5.7",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "prop-types": "^15.5.7"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
   "author": "haoxin",
   "license": "MIT",
   "dependencies": {
-    "flatpickr": "^2.3.5"
+    "flatpickr": "^2.3.5",
+    "prop-types": "^15.5.7",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",


### PR DESCRIPTION
react-flatpickr uses prop-types, but doesn't declare a dependency on it, so it breaks if nothing else in the consuming project causes prop-types to be installed.