### PR TITLE
Fix "value" type validation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,8 @@ class DateTimePicker extends Component {
     value: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.array,
-      PropTypes.object
+      PropTypes.object,
+      PropTypes.number,
     ]),
     children: PropTypes.node
   }


### PR DESCRIPTION
Flatpickr can accept timestamp as valid date value: [parseDate](https://github.com/chmln/flatpickr/blob/master/src/flatpickr.js#L2581)