### PR TITLE
Add default onClose option to clear focus when input is used

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Flatpickr from 'flatpickr'
@@ -39,7 +38,7 @@ class DateTimePicker extends Component {
   }
 
   componentWillReceiveProps(props) {
-    const { options } = props
+    const {options} = props
 
     if (props.hasOwnProperty('value')) {
       this.flatpickr.setDate(props.value, false)
@@ -69,6 +68,9 @@ class DateTimePicker extends Component {
 
   componentDidMount() {
     const options = {
+      onClose: () => {
+        this.node.blur && this.node.blur()
+      },
       ...this.props.options
     }
 
@@ -92,7 +94,7 @@ class DateTimePicker extends Component {
 
   render() {
     // eslint-disable-next-line no-unused-vars
-    const { options, defaultValue, value, children, ...props } = this.props
+    const {options, defaultValue, value, children, ...props} = this.props
 
     // Don't pass hooks to dom node
     for (let hook of hooks) {
@@ -107,7 +109,7 @@ class DateTimePicker extends Component {
       )
       : (
         <input {...props} defaultValue={defaultValue}
-          ref={node => { this.node = node }} />
+               ref={node => { this.node = node }}/>
       )
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ class DateTimePicker extends Component {
   }
 
   componentWillReceiveProps(props) {
-    const {options} = props
+    const { options } = props
 
     if (props.hasOwnProperty('value')) {
       this.flatpickr.setDate(props.value, false)
@@ -94,7 +94,7 @@ class DateTimePicker extends Component {
 
   render() {
     // eslint-disable-next-line no-unused-vars
-    const {options, defaultValue, value, children, ...props} = this.props
+    const { options, defaultValue, value, children, ...props } = this.props
 
     // Don't pass hooks to dom node
     for (let hook of hooks) {
@@ -109,7 +109,7 @@ class DateTimePicker extends Component {
       )
       : (
         <input {...props} defaultValue={defaultValue}
-               ref={node => { this.node = node }}/>
+          ref={node => { this.node = node }} />
       )
   }
 }


### PR DESCRIPTION
Currently (when input field is used)  if you close the picker (by clicking beside the picker) and try to open it again, it's doesn't work because input field is focused, blur was needed