### PR TITLE
Update flatpickr dependency for SSR support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "haoxin",
   "license": "MIT",
   "dependencies": {
-    "flatpickr": "^4.0.1",
+    "flatpickr": "^4.0.5",
     "prop-types": "^15.5.10"
   },
   "devDependencies": {


### PR DESCRIPTION
The upgrade to flatpickr 4 broke server-side rendering, re-breaking #9.

It's been fixed in flatpickr v4.0.5, via [chmin/flatpickr#1069](https://github.com/chmln/flatpickr/pull/1069), so this bumps the minimum version dependency.