### PR TITLE
disable altInput based on props

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,8 +40,10 @@ class DateTimePicker extends Component {
   }
 
   componentWillReceiveProps(props) {
-    const { options } = props
+    const { options, disabled } = props
     const prevOptions = this.props.options
+
+    if (this.flatpickr.altInput) this.flatpickr.altInput.disabled = disabled;
 
     // Add prop hooks to options
     hooks.forEach(hook => {
@@ -91,6 +93,7 @@ class DateTimePicker extends Component {
     })
 
     this.flatpickr = new Flatpickr(this.node, options)
+    if (this.flatpickr.altInput) this.flatpickr.altInput.disabled = this.props.disabled;
 
     if (this.props.hasOwnProperty('value')) {
       this.flatpickr.setDate(this.props.value, false)


### PR DESCRIPTION
This small PR is to ensure that if Flatpickr has a disabled prop, the altInput element also behaves accordingly.