### PR TITLE
Update flatpickr version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "haoxin",
   "license": "MIT",
   "dependencies": {
-    "flatpickr": "^4.0.5",
+    "flatpickr": "^4.3.2",
     "prop-types": "^15.5.10"
   },
   "devDependencies": {


### PR DESCRIPTION
When the Flatpickr is implemented on bootstrap modal it closes on any click, even if  `closeOnSelect: false` is set it as option config