### PR TITLE
Fixed path to CSS in node_modules

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@
 ## Usage
 
 ```jsx
-import 'flatpickr/dist/themes/material_green.min.css'
+import 'flatpickr/dist/themes/material_green.css'
 
 import Flatpickr from 'react-flatpickr'
 import { Component } from 'react'


### PR DESCRIPTION
The CSS is longer minified (apparently), and so this path doesn't exist.