### PR TITLE
do not warn when pass array of functions to hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 package-lock.json
+yarn.lock
 npm-debug.log
 node_modules/
 .DS_Store

--- a/example/index.js
+++ b/example/index.js
@@ -31,7 +31,10 @@ class App extends Component {
     return (
       <main>
         <Flatpickr data-enable-time className='test'
-          onChange={(_, str) => console.info(str)} />
+          onChange={[
+            (_, str) => console.info(str),
+            () => {} // test hookPropType
+          ]} />
         <Flatpickr data-enable-time defaultValue='2016-11-11 11:11'
           onChange={(_, str) => console.info(str)} />
         <Flatpickr data-enable-time value={v}

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,19 +13,23 @@ const hooks = [
   'onValueUpdate',
   'onDayCreate'
 ]
+const hookPropType = PropTypes.oneOfType([
+  PropTypes.func,
+  PropTypes.arrayOf(PropTypes.func)
+])
 
 class DateTimePicker extends Component {
   static propTypes = {
     defaultValue: PropTypes.string,
     options: PropTypes.object,
-    onChange: PropTypes.func,
-    onOpen: PropTypes.func,
-    onClose: PropTypes.func,
-    onMonthChange: PropTypes.func,
-    onYearChange: PropTypes.func,
-    onReady: PropTypes.func,
-    onValueUpdate: PropTypes.func,
-    onDayCreate: PropTypes.func,
+    onChange: hookPropType,
+    onOpen: hookPropType,
+    onClose: hookPropType,
+    onMonthChange: hookPropType,
+    onYearChange: hookPropType,
+    onReady: hookPropType,
+    onValueUpdate: hookPropType,
+    onDayCreate: hookPropType,
     value: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.array,


### PR DESCRIPTION
Hi 😀.

By [documentation](https://flatpickr.js.org/events/#events) for each hook you can specify a single function or an array of functions.

Now I have warnings when passing an array of functions:

![warnings](https://user-images.githubusercontent.com/2676086/51880870-9b9cab00-2381-11e9-9490-ac80f9813f0a.jpg)
