### PR TITLE
Add className to propTypes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,8 @@ class DateTimePicker extends Component {
       PropTypes.object,
       PropTypes.number
     ]),
-    children: PropTypes.node
+    children: PropTypes.node,
+    className: PropTypes.string
   }
 
   static defaultProps = {


### PR DESCRIPTION
Hi! First, thank you for this package.

I'm using this component in a TypeScript project with strict type checking enabled, because of that, I can't define a className like you did in your example
```js
<Flatpickr data-enable-time className='test' ... />
```
So before making a PL in the [DefinitelyTyped repo](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-flatpickr/index.d.ts), I thought it's better to add it first here to keep the two repos synchronized.

Thanks in advance.